### PR TITLE
Semi-transparent colors should not return a name.

### DIFF
--- a/tinycolor.js
+++ b/tinycolor.js
@@ -106,7 +106,7 @@ function tinycolor (color, opts) {
                 return "transparent";
             }
 
-            return hexNames[rgbToHex(r, g, b, true)] || false;
+            return (a === 1) ? hexNames[rgbToHex(r, g, b, true)] || false : false;
         },
         toFilter: function(secondColor) {
             var hex8String = '#' + rgbaToHex(r, g, b, a);


### PR DESCRIPTION
If a name is returned for a color that has transparency and that name is interpreted by html or css, the transparency is lost.
