### PR TITLE
Adjust AMD module definition to better support r.js namespacing

### DIFF
--- a/tinycolor.js
+++ b/tinycolor.js
@@ -952,7 +952,7 @@ if (typeof module !== "undefined" && module.exports) {
     module.exports = tinycolor;
 }
 // AMD/requirejs: Define the module
-else if (typeof define !== "undefined") {
+else if (typeof define === 'function' && define.amd) {
     define(function () {return tinycolor;});
 }
 // Browser: Expose to window


### PR DESCRIPTION
r.js requires a very specific pattern for detecting AMD in order to write the define calls to support namespacing (https://github.com/jrburke/r.js/blob/master/dist/r.js#L23958). This adjusts the condition to match the expected pattern.
