### PR TITLE
Add allhex.txt 11.7MB text blob to .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,1 @@
+test/allhex.txt


### PR DESCRIPTION
Adds test/allhex.txt to .npmignore to avoid downloading an extra 11.7MB (out of 12.7MB) when installing via npm for a file that isn't even used.
