### PR TITLE
Added HSVA regex pattern.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -164,6 +164,7 @@ test("Hex Parsing", function() {
 test("HSV Parsing", function() {
   equal (tinycolor("hsv 251.1 0.887 .918").toHsvString(), "hsv(251, 89%, 92%)");
   equal (tinycolor("hsv 251.1 0.887 0.918").toHsvString(), "hsv(251, 89%, 92%)");
+  equal (tinycolor("hsva 251.1 0.887 0.918 0.5").toHsvString(), "hsva(251, 89%, 92%, 0.5)");
 });
 
 test("Invalid Parsing", function() {

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -1026,6 +1026,7 @@ var matchers = (function() {
         hsl: new RegExp("hsl" + PERMISSIVE_MATCH3),
         hsla: new RegExp("hsla" + PERMISSIVE_MATCH4),
         hsv: new RegExp("hsv" + PERMISSIVE_MATCH3),
+        hsva: new RegExp("hsva" + PERMISSIVE_MATCH4),
         hex3: /^([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
         hex6: /^([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/,
         hex8: /^([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/
@@ -1066,6 +1067,9 @@ function stringInputToObject(color) {
     }
     if ((match = matchers.hsv.exec(color))) {
         return { h: match[1], s: match[2], v: match[3] };
+    }
+    if ((match = matchers.hsva.exec(color))) {
+        return { h: match[1], s: match[2], v: match[3], a: match[4] };
     }
     if ((match = matchers.hex8.exec(color))) {
         return {


### PR DESCRIPTION
This adds support for the `HSVA` color format. While editing color values in [Spectrum](https://github.com/bgrins/spectrum) I found that `HSVA` colors were showing up as invalid. This update fixes the issue.

Existing Code: http://jsfiddle.net/neogeek/xmfdLmu9/

With Pull Request Code: http://jsfiddle.net/neogeek/xmfdLmu9/1
