### PR TITLE
remove function expression, breaks IE8 if minified and not needed

### DIFF
--- a/tinycolor.js
+++ b/tinycolor.js
@@ -13,7 +13,7 @@ var trimLeft = /^[\s,#]+/,
     mathMax = math.max,
     mathRandom = math.random;
 
-var tinycolor = function (color, opts) {
+function tinycolor (color, opts) {
 
     color = (color) ? color : '';
     opts = opts || { };
@@ -47,7 +47,7 @@ var tinycolor = function (color, opts) {
 
     this._ok = rgb.ok;
     this._tc_id = tinyCounter++;
-};
+}
 
 tinycolor.prototype = {
     isDark: function() {

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -13,7 +13,7 @@ var trimLeft = /^[\s,#]+/,
     mathMax = math.max,
     mathRandom = math.random;
 
-var tinycolor = function tinycolor (color, opts) {
+var tinycolor = function (color, opts) {
 
     color = (color) ? color : '';
     opts = opts || { };


### PR DESCRIPTION
Basically same exact issue here:
https://github.com/hammerjs/jquery.hammer.js/issues/20

This statement 
```
    var tinycolor = function tinycolor (color, opts) {
      ..... 
    }
```
Becomes after minification
```
            Q = function U(a, c) {
```

Which confuses IE8

### Quick test example for your references 
(I didn't find an online jsfiddle-like tool that works with ie8)

```javascript
        var Foo = function Bar() {
            if (!(this instanceof Bar)) return new Bar();
        };
        Foo.prototype = {
            someMethod: function() {}
        };
        console.log(Foo().someMethod);
        // print undefined in ie8
```