### PR TITLE
added handling of numbers for Pixi.js hex format with tests

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -729,3 +729,14 @@ test("tetrad", function() {
   var combination = tinycolor("red").tetrad();
   equal(colorsToHexString(combination), "ff0000,80ff00,00ffff,7f00ff", "Correct Combination");
 });
+
+
+test("NumberHex", function () {
+  equal( tinycolor(0x0).toString(), "#000000") 
+
+  equal( tinycolor("rgb(18, 0, 0)").toString(), tinycolor(0x120000).toString()) 
+  equal( tinycolor("rgb(0, 52, 0)").toString(), tinycolor(0x3400).toString()) 
+  equal( tinycolor("rgb(0, 0, 86)").toString(), tinycolor(0x56).toString()) 
+
+  equal( tinycolor("rgb(0, 0, 86)").toNumber(), 0x134)   
+})

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -18,14 +18,18 @@ function tinycolor (color, opts) {
     color = (color) ? color : '';
     opts = opts || { };
 
+
+
     // If input is already a tinycolor, return itself
     if (color instanceof tinycolor) {
        return color;
     }
+
     // If we are called as a function, call using new instead
     if (!(this instanceof tinycolor)) {
         return new tinycolor(color, opts);
     }
+
 
     var rgb = inputToRGB(color);
     this._originalInput = color,
@@ -163,6 +167,9 @@ tinycolor.prototype = {
         }
 
         return "progid:DXImageTransform.Microsoft.gradient("+gradientType+"startColorstr="+hex8String+",endColorstr="+secondHex8String+")";
+    },
+    toNumber: function() {
+        return (mathRound(this._r)<<16) + (mathRound(this._g)<<8) + (mathRound(this._b))
     },
     toString: function(format) {
         var formatSet = !!format;
@@ -304,7 +311,12 @@ function inputToRGB(color) {
     var ok = false;
     var format = false;
 
-    if (typeof color == "string") {
+    if (typeof color == "number") {
+        color = numberInputToObject(color)
+        // color.toString(16);
+        // color = '#' + ('000000'+color).substring(color.length);
+    }
+    else if (typeof color == "string") {
         color = stringInputToObject(color);
     }
 
@@ -1063,6 +1075,17 @@ var matchers = (function() {
         hex8: /^([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})([0-9a-fA-F]{2})$/
     };
 })();
+
+
+// `numberInputToObject`
+// Take in a number
+function numberInputToObject(color) {
+    return {
+        r: color >> 16, 
+        g: (color&0xff00) >> 8,
+        b: color&0xff
+    }
+}
 
 // `stringInputToObject`
 // Permissive string parsing.  Take in a number of formats, and output an object


### PR DESCRIPTION
This adds support for raw hex format like in Pixi.js, for example '0xaabbcc` is the same color as `#aabbcc`