### PR TITLE
Spinning by -360, 0 or 360 should have no effect

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -691,6 +691,12 @@ test("Spin", function () {
     equal (Math.round(tinycolor("#f00").spin(10).toHsl().h), 10, "Spinning 10 works");
     equal (Math.round(tinycolor("#f00").spin(360).toHsl().h), 0, "Spinning 360 works");
     equal (Math.round(tinycolor("#f00").spin(2345).toHsl().h), 185, "Spinning 2345 works");
+
+    [-360, 0, 360].forEach(function (delta) {
+      Object.keys(tinycolor.names).forEach(function (name) {
+        equal(tinycolor(name).toHex(), tinycolor(name).spin(delta).toHex(), "Spinning " + delta.toString() + " has no effect")
+      })
+    })
 });
 
 test("Mix", function () {

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -593,7 +593,7 @@ function darken (color, amount) {
 // Values outside of this range will be wrapped into this range.
 function spin(color, amount) {
     var hsl = tinycolor(color).toHsl();
-    var hue = (mathRound(hsl.h) + amount) % 360;
+    var hue = (hsl.h + amount) % 360;
     hsl.h = hue < 0 ? 360 + hue : hue;
     return tinycolor(hsl);
 }


### PR DESCRIPTION
The documentation states that "Calling [spin] with 0, 360, or -360 will do nothing (since it sets the hue back to what it was before)" however this is not the case, due to rounding of hue in the spin function. This is shown in the test in f543284 and fixed in e77ff38. Without this fix, around 20% of the named colors are changed when spun by 0:

```javascript
Object.keys(tinycolor.names).filter(function (name) {
  return tinycolor(name).spin(0).toHex() !== tinycolor(name).toHex()
}).length;

// -> 30
```