### PR TITLE
Ensure that all named colors are predictably retrievable

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -205,7 +205,6 @@ test("Invalid Parsing", function() {
 test("Named colors", function() {
   equal (tinycolor("aliceblue").toHex(), "f0f8ff");
   equal (tinycolor("antiquewhite").toHex(), "faebd7");
-  equal (tinycolor("aqua").toHex(), "00ffff");
   equal (tinycolor("aquamarine").toHex(), "7fffd4");
   equal (tinycolor("azure").toHex(), "f0ffff");
   equal (tinycolor("beige").toHex(), "f5f5dc");
@@ -248,13 +247,11 @@ test("Named colors", function() {
   equal (tinycolor("firebrick").toHex(), "b22222");
   equal (tinycolor("floralwhite").toHex(), "fffaf0");
   equal (tinycolor("forestgreen").toHex(), "228b22");
-  equal (tinycolor("fuchsia").toHex(), "ff00ff");
   equal (tinycolor("gainsboro").toHex(), "dcdcdc");
   equal (tinycolor("ghostwhite").toHex(), "f8f8ff");
   equal (tinycolor("gold").toHex(), "ffd700");
   equal (tinycolor("goldenrod").toHex(), "daa520");
   equal (tinycolor("gray").toHex(), "808080");
-  equal (tinycolor("grey").toHex(), "808080");
   equal (tinycolor("green").toHex(), "008000");
   equal (tinycolor("greenyellow").toHex(), "adff2f");
   equal (tinycolor("honeydew").toHex(), "f0fff0");
@@ -271,7 +268,6 @@ test("Named colors", function() {
   equal (tinycolor("lightcoral").toHex(), "f08080");
   equal (tinycolor("lightcyan").toHex(), "e0ffff");
   equal (tinycolor("lightgoldenrodyellow").toHex(), "fafad2");
-  equal (tinycolor("lightgrey").toHex(), "d3d3d3");
   equal (tinycolor("lightgreen").toHex(), "90ee90");
   equal (tinycolor("lightpink").toHex(), "ffb6c1");
   equal (tinycolor("lightsalmon").toHex(), "ffa07a");

--- a/test/test.js
+++ b/test/test.js
@@ -348,6 +348,10 @@ test("Named colors", function() {
 
   equal (tinycolor("#f00").toName(), "red");
   equal (tinycolor("#fa0a0a").toName(), false);
+
+  Object.keys(tinycolor.names).forEach(function (name) {
+    equal(name, tinycolor(name).toName(), "Named color should be invertible");
+  })
 });
 
 

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -794,7 +794,7 @@ tinycolor.mostReadable = function(baseColor, colorList, args) {
 var names = tinycolor.names = {
     aliceblue: "f0f8ff",
     antiquewhite: "faebd7",
-    aqua: "0ff",
+    // aqua: "0ff",  // use "cyan"
     aquamarine: "7fffd4",
     azure: "f0ffff",
     beige: "f5f5dc",
@@ -819,7 +819,7 @@ var names = tinycolor.names = {
     darkgoldenrod: "b8860b",
     darkgray: "a9a9a9",
     darkgreen: "006400",
-    darkgrey: "a9a9a9",
+    // darkgrey: "a9a9a9",  // use "darkgray"
     darkkhaki: "bdb76b",
     darkmagenta: "8b008b",
     darkolivegreen: "556b2f",
@@ -830,18 +830,18 @@ var names = tinycolor.names = {
     darkseagreen: "8fbc8f",
     darkslateblue: "483d8b",
     darkslategray: "2f4f4f",
-    darkslategrey: "2f4f4f",
+    // darkslategrey: "2f4f4f",  // use "darkgray"
     darkturquoise: "00ced1",
     darkviolet: "9400d3",
     deeppink: "ff1493",
     deepskyblue: "00bfff",
     dimgray: "696969",
-    dimgrey: "696969",
+    // dimgrey: "696969",  // use "dimgray"
     dodgerblue: "1e90ff",
     firebrick: "b22222",
     floralwhite: "fffaf0",
     forestgreen: "228b22",
-    fuchsia: "f0f",
+    // fuchsia: "f0f",  // use "magenta"
     gainsboro: "dcdcdc",
     ghostwhite: "f8f8ff",
     gold: "ffd700",
@@ -849,7 +849,7 @@ var names = tinycolor.names = {
     gray: "808080",
     green: "008000",
     greenyellow: "adff2f",
-    grey: "808080",
+    // grey: "808080", // use "gray"
     honeydew: "f0fff0",
     hotpink: "ff69b4",
     indianred: "cd5c5c",
@@ -866,13 +866,13 @@ var names = tinycolor.names = {
     lightgoldenrodyellow: "fafad2",
     lightgray: "d3d3d3",
     lightgreen: "90ee90",
-    lightgrey: "d3d3d3",
+    // lightgrey: "d3d3d3",  // use "lightgray"
     lightpink: "ffb6c1",
     lightsalmon: "ffa07a",
     lightseagreen: "20b2aa",
     lightskyblue: "87cefa",
     lightslategray: "789",
-    lightslategrey: "789",
+    // lightslategrey: "789",  // use "lightslategray"
     lightsteelblue: "b0c4de",
     lightyellow: "ffffe0",
     lime: "0f0",
@@ -926,7 +926,7 @@ var names = tinycolor.names = {
     skyblue: "87ceeb",
     slateblue: "6a5acd",
     slategray: "708090",
-    slategrey: "708090",
+    // slategrey: "708090",  // use "slategray"
     snow: "fffafa",
     springgreen: "00ff7f",
     steelblue: "4682b4",

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -912,7 +912,7 @@ var names = tinycolor.names = {
     plum: "dda0dd",
     powderblue: "b0e0e6",
     purple: "800080",
-    rebeccapurple: "663399",
+    rebeccapurple: "639",
     red: "f00",
     rosybrown: "bc8f8f",
     royalblue: "4169e1",


### PR DESCRIPTION
While I can understand why the same hex color was added under multiple names, this has the unpredictable result that calling `toName` on a color constructed with a name returns a different name:

```javascript
tinycolor('aqua').toName()  // -> 'cyan'
```

This happens for ten named colors right now. Nine of these are due to duplicate names for the same hex value (fixed in dd1b8fe) and one is due to the fact that "rebeccapurple" was added with a six character hex but is looked up with a three character hex (fixed in 47f0bd8).

I had a look and couldn't see a preferred deprecation strategy in this project, so I just removed the offending colors to demonstrate the point, and can modify this PR to follow a deprecation strategy if needed.