### PR TITLE
Fixes original color object modified by reference.

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,10 @@ test("TinyColor initialization", function() {
   ok(new tinycolor(r) === r, "when given a tinycolor instance, new tinycolor() returns it");
   equal(tinycolor("red", { format: "hex" }).toString(), "#ff0000", "tinycolor options are being parsed");
   equal(tinycolor.fromRatio({r: 1, g: 0, b: 0 }, { format: "hex" }).toString(), "#ff0000", "tinycolor options are being parsed");
+
+  var obj = {h: 180, s: 0.5, l: 0.5};
+  var color = tinycolor(obj);
+  ok(obj.s === 0.5, "when given an object, the original object is not modified");
 });
 
 test("Original input", function() {

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -303,6 +303,9 @@ function inputToRGB(color) {
 
     var rgb = { r: 0, g: 0, b: 0 };
     var a = 1;
+    var s = null;
+    var v = null;
+    var l = null;
     var ok = false;
     var format = false;
 
@@ -317,16 +320,16 @@ function inputToRGB(color) {
             format = String(color.r).substr(-1) === "%" ? "prgb" : "rgb";
         }
         else if (isValidCSSUnit(color.h) && isValidCSSUnit(color.s) && isValidCSSUnit(color.v)) {
-            color.s = convertToPercentage(color.s);
-            color.v = convertToPercentage(color.v);
-            rgb = hsvToRgb(color.h, color.s, color.v);
+            s = convertToPercentage(color.s);
+            v = convertToPercentage(color.v);
+            rgb = hsvToRgb(color.h, s, v);
             ok = true;
             format = "hsv";
         }
         else if (isValidCSSUnit(color.h) && isValidCSSUnit(color.s) && isValidCSSUnit(color.l)) {
-            color.s = convertToPercentage(color.s);
-            color.l = convertToPercentage(color.l);
-            rgb = hslToRgb(color.h, color.s, color.l);
+            s = convertToPercentage(color.s);
+            l = convertToPercentage(color.l);
+            rgb = hslToRgb(color.h, s, l);
             ok = true;
             format = "hsl";
         }


### PR DESCRIPTION
This is more of a targeted fix than doing something like unilaterally cloning the input object. I don't see any other offenders in `inputToRBG()`.