### PR TITLE
chore: remove star copy from docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ after_success:
   - bash <(curl -s https://codecov.io/bash)
   - npm run travis-deploy-once "npm run semantic-release"
   - npm run build:demo
-  - cp -r demo/public/* docs
+  - cp -r demo/public/ docs
   - npm run build:docs
 deploy:
   provider: pages


### PR DESCRIPTION
whoops

also, i've updated the live demo 
https://typectrl.github.io/tinycolor/

where you can see `tinycolor('red')` working in the console