### PR TITLE
WIP - add test for functional creation

### DIFF
--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,4 +1,5 @@
 import TinyColor from '../src/public_api';
+import TinyColorDist from '../dist/public_api';
 
 const {
   fromRatio,
@@ -24,6 +25,12 @@ describe('TinyColor', () => {
   it('should init', () => {
     const r = new TinyColor('red');
     expect(r).toBeInstanceOf(TinyColor);
+    expect(r.toName()).toBe('red');
+    expect(r).toBeTruthy();
+  });
+  it('should init with function', () => {
+    const r = TinyColorDist('red');
+    expect(r).toBeInstanceOf(TinyColorDist);
     expect(r.toName()).toBe('red');
     expect(r).toBeTruthy();
   });


### PR DESCRIPTION
I realized that the functional creation does actually work in node as well, it just doesn't in the test when we import from `import TinyColor from '../src/public_api';` because I guess that's not compiling down to es2015, or something.

This isn't landable since it will break tests if `npm run build` didn't happen first. But I'm now wondering though.. should we be testing against dist/ instead of src/? I could see a gap where all tests pass against src/ but there was a bug with the build / packaging itself and we shipped out a broken dist/? Or is that a narrow enough gap that it's not worth worrying about. @scttcper any thoughts? I'm not sure what's normally done with TS projects.