### PR TITLE
Fix less.js functions link

### DIFF
--- a/index.html
+++ b/index.html
@@ -195,7 +195,7 @@
 	   Developed by <a href='http://briangrinstead.com'>Brian Grinstead</a>.  Big thanks to the following places:
 	</p>
 	<ul>
-	   <li><a href='https://github.com/cloudhead/less.js/blob/master/lib/less/functions.js'>less.js</a> for some of the modification functions</li>
+	   <li><a href='https://github.com/less/less.js/tree/master/lib/less/functions'>less.js</a> for some of the modification functions</li>
 	   <li><a href='https://github.com/infusion/jQuery-xcolor/blob/master/jquery.xcolor.js'>jQuery xColor</a> for some of the combination functions</li>
 	   <li><a href='http://www.w3.org/TR/css3-color/#svg-color'>w3.org</a> for the color list and parsing rules</li>
 	   <li><a href='http://mjijackson.com/2008/02/rgb-to-hsl-and-rgb-to-hsv-color-model-conversion-algorithms-in-javascript'>mjijackson.com</a> for the first stab at RGB / HSL / HSV converters</li>


### PR DESCRIPTION
The less.js functions link returned a 404 page, so I updated the URL.