### PR TITLE
Updated grunt-contrib-qunit version to 3.0.1 to replace phantomjs dependency with chromium puppeteer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-    - "0.11"
+    - "12"
 before_script:
     - npm install -g grunt-cli
 script:

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "grunt": "~0.4.1",
     "grunt-contrib-concat": "~0.1.3",
     "grunt-contrib-jshint": "~0.1.1",
-    "grunt-contrib-qunit": "^0.7.0",
+    "grunt-contrib-qunit": "^4.0.0",
     "grunt-contrib-uglify": "~0.2.0",
     "grunt-docco": "~0.2.0"
   }


### PR DESCRIPTION
Updated grunt-contrib-qunit version from 0.7.0 to 3.0.1 to replace phantomjs dependency with chromium puppeteer as phantomjs is currently unmaintained.
**Output after update**:
> puppeteer@1.7.0 install /TinyColor/node_modules/puppeteer
> node install.js

Downloading Chromium r579032 - 102.3 Mb [====================] 100% 0.0s
Chromium downloaded to /TinyColor/node_modules/puppeteer/.local-chromium/linux-579032
npm notice created a lockfile as package-lock.json. You should commit this file.
added 45 packages from 29 contributors, removed 3 packages and audited 192 packages in 20.434s
found 20 vulnerabilities (12 low, 8 high)
  run `npm audit fix` to fix them, or `npm audit` for details
