### PR TITLE
Drop ID counter

### DIFF
--- a/tinycolor.js
+++ b/tinycolor.js
@@ -6,7 +6,6 @@
 
 var trimLeft = /^\s+/,
     trimRight = /\s+$/,
-    tinyCounter = 0,
     mathRound = Math.round,
     mathMin = Math.min,
     mathMax = Math.max,
@@ -45,7 +44,6 @@ function tinycolor (color, opts) {
     if (this._b < 1) { this._b = mathRound(this._b); }
 
     this._ok = rgb.ok;
-    this._tc_id = tinyCounter++;
 }
 
 tinycolor.prototype = {


### PR DESCRIPTION
Drop unnecessary tinycolor object ID counting which was introduced in https://github.com/bgrins/TinyColor/commit/904669c4cc1b280222c6218f9e1a5b4cc9614d67 and used for checking if an object is a tinycolor instance. The check was then rewritten in https://github.com/bgrins/TinyColor/commit/5b4ec7e3d1d3150510399830db9d10055f065f87 to not require the ID. In addition to needlessly occupying space, the running ID prevents naive deep equality tests from working.