### PR TITLE
Add a browser entry field in package.json. This fixes a reported case…

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -19,6 +19,7 @@
   },
   "module": "./esm/tinycolor.js",
   "main": "./cjs/tinycolor.js",
+  "browser": "./cjs/tinycolor.js",
   "exports": {
     ".": {
       "import": "./esm/tinycolor.js",


### PR DESCRIPTION
… of a build tool using the ESM export, and does not seem to negatively affect other tools which ignore this in lieu of the exports section - see for example https://webpack.js.org/guides/package-exports/. Fixes #249