### PR TITLE
Convert HSL to HSLA

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ tinycolor.fromRatio({ r: .5, g: .5, b: .5 });
 ### HSL, HSLA
 ```js
 tinycolor("hsl(0, 100%, 50%)");
-tinycolor("hsla(0, 100%, 50%, .5)");
+tinycolor("hsl(0, 100%, 50%, .5)");
 tinycolor("hsl(0, 100%, 50%)");
 tinycolor("hsl 0 1.0 0.5");
 tinycolor({ h: 0, s: 1, l: .5 });
@@ -247,7 +247,7 @@ color.toHsl(); // { h: 0, s: 1, l: 0.5, a: 1 }
 var color = tinycolor("red");
 color.toHslString(); // "hsl(0, 100%, 50%)"
 color.setAlpha(0.5);
-color.toHslString(); // "hsla(0, 100%, 50%, 0.5)"
+color.toHslString(); // "hsl(0, 100%, 50%, 0.5)"
 ```
 ### toHex
 ```js

--- a/mod.js
+++ b/mod.js
@@ -107,7 +107,7 @@ tinycolor.prototype = {
       l = Math.round(hsl.l * 100);
     return this._a == 1
       ? "hsl(" + h + ", " + s + "%, " + l + "%)"
-      : "hsla(" + h + ", " + s + "%, " + l + "%, " + this._roundA + ")";
+      : "hsl(" + h + ", " + s + "%, " + l + "%, " + this._roundA + ")";
   },
   toHex: function (allow3Char) {
     return rgbToHex(this._r, this._g, this._b, allow3Char);
@@ -353,7 +353,7 @@ tinycolor.fromRatio = function (color, opts) {
 //     "rgba (255, 0, 0, 1)" or "rgba 255, 0, 0, 1"
 //     "rgba (1.0, 0, 0, 1)" or "rgba 1.0, 0, 0, 1"
 //     "hsl(0, 100%, 50%)" or "hsl 0 100% 50%"
-//     "hsla(0, 100%, 50%, 1)" or "hsla 0 100% 50%, 1"
+//     "hsl(0, 100%, 50%, 1)" or "hsl 0 100% 50%, 1"
 //     "hsv(0, 100%, 100%)" or "hsv 0 100% 100%"
 //
 function inputToRGB(color) {
@@ -1167,7 +1167,7 @@ var matchers = (function () {
     rgb: new RegExp("rgb" + PERMISSIVE_MATCH3),
     rgba: new RegExp("rgba" + PERMISSIVE_MATCH4),
     hsl: new RegExp("hsl" + PERMISSIVE_MATCH3),
-    hsla: new RegExp("hsla" + PERMISSIVE_MATCH4),
+    hsla: new RegExp("hsla?" + PERMISSIVE_MATCH4),
     hsv: new RegExp("hsv" + PERMISSIVE_MATCH3),
     hsva: new RegExp("hsva" + PERMISSIVE_MATCH4),
     hex3: /^#?([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
@@ -1208,11 +1208,10 @@ function stringInputToObject(color) {
   if ((match = matchers.rgba.exec(color))) {
     return { r: match[1], g: match[2], b: match[3], a: match[4] };
   }
-  if ((match = matchers.hsl.exec(color))) {
-    return { h: match[1], s: match[2], l: match[3] };
-  }
   if ((match = matchers.hsla.exec(color))) {
     return { h: match[1], s: match[2], l: match[3], a: match[4] };
+  } else if ((match = matchers.hsl.exec(color))) {
+    return { h: match[1], s: match[2], l: match[3] };
   }
   if ((match = matchers.hsv.exec(color))) {
     return { h: match[1], s: match[2], v: match[3] };

--- a/test.js
+++ b/test.js
@@ -459,13 +459,23 @@ Deno.test("HSL parsing", function () {
   );
   assertEquals(
     tinycolor({ h: 251, s: 100, l: 0.38, a: 0.5 }).toHslString(),
-    "hsla(251, 100%, 38%, 0.5)",
-    "to hsla"
+    "hsl(251, 100%, 38%, 0.5)",
+    "to hsl"
   );
   assertEquals(
     tinycolor("hsl(251, 100, 38)").toHexString(),
     "#2400c2",
     "to hex"
+  );
+  assertEquals(
+    tinycolor("hsl(251, 100, 38, .5)").toHslString(),
+    "hsl(251, 100%, 38%, 0.5)",
+    `to hsl ${color}, `
+  );
+  assertEquals(
+    tinycolor("hsla(251, 100, 38, .5)").toHslString(),
+    "hsl(251, 100%, 38%, 0.5)",
+    "to hsl"
   );
   assertEquals(
     tinycolor("hsl(251, 100%, 38%)").toRgbString(),

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -115,7 +115,7 @@
       var h = Math.round(hsl.h * 360),
         s = Math.round(hsl.s * 100),
         l = Math.round(hsl.l * 100);
-      return this._a == 1 ? "hsl(" + h + ", " + s + "%, " + l + "%)" : "hsla(" + h + ", " + s + "%, " + l + "%, " + this._roundA + ")";
+      return this._a == 1 ? "hsl(" + h + ", " + s + "%, " + l + "%)" : "hsl(" + h + ", " + s + "%, " + l + "%, " + this._roundA + ")";
     },
     toHex: function toHex(allow3Char) {
       return rgbToHex(this._r, this._g, this._b, allow3Char);
@@ -303,7 +303,7 @@
   //     "rgba (255, 0, 0, 1)" or "rgba 255, 0, 0, 1"
   //     "rgba (1.0, 0, 0, 1)" or "rgba 1.0, 0, 0, 1"
   //     "hsl(0, 100%, 50%)" or "hsl 0 100% 50%"
-  //     "hsla(0, 100%, 50%, 1)" or "hsla 0 100% 50%, 1"
+  //     "hsl(0, 100%, 50%, 1)" or "hsl 0 100% 50%, 1"
   //     "hsv(0, 100%, 100%)" or "hsv 0 100% 100%"
   //
   function inputToRGB(color) {
@@ -1038,7 +1038,7 @@
       rgb: new RegExp("rgb" + PERMISSIVE_MATCH3),
       rgba: new RegExp("rgba" + PERMISSIVE_MATCH4),
       hsl: new RegExp("hsl" + PERMISSIVE_MATCH3),
-      hsla: new RegExp("hsla" + PERMISSIVE_MATCH4),
+      hsl: new RegExp("hsl" + PERMISSIVE_MATCH4),
       hsv: new RegExp("hsv" + PERMISSIVE_MATCH3),
       hsva: new RegExp("hsva" + PERMISSIVE_MATCH4),
       hex3: /^#?([0-9a-fA-F]{1})([0-9a-fA-F]{1})([0-9a-fA-F]{1})$/,
@@ -1101,7 +1101,7 @@
         l: match[3]
       };
     }
-    if (match = matchers.hsla.exec(color)) {
+    if (match = matchers.hsl.exec(color)) {
       return {
         h: match[1],
         s: match[2],


### PR DESCRIPTION
As explained on the [MDN page for `hsl()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/hsl). The `hsla()` function is a legacy alias for `hsl()`.

This library would not parse correctly HSL color that have an alpha channel using the `hsl()` function.

This pull request changes the parsing so that it accepts both `hsl()` and `hsla()`. And it will always output `hsl()`.