### PR TITLE
Add failing rgba float test

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,6 +274,12 @@ color.toHex8String(); // "#ff0000ff"
 var color = tinycolor("red");
 color.toRgb(); // { r: 255, g: 0, b: 0, a: 1 }
 ```
+### toRgbValues
+Like `toRgb` but values are not rounded.
+```js
+var color = tinycolor("rgb(33.3, 66.7, 1)");
+color.toRgbValues(); // { r: 33.3, g: 66.7, b: 1, a: 1 }
+```
 ### toRgbString
 ```js
 var color = tinycolor("red");

--- a/test.js
+++ b/test.js
@@ -330,6 +330,16 @@ Deno.test("RGB Text Parsing", function () {
     "parenthesized spaced input"
   );
   assertEquals(
+    tinycolor("rgba(255, 25.5, 0, 0.5)").toRgb(),
+    {
+      r: 255,
+      g: 25.5,
+      b: 0,
+      a: 0.5,
+    },
+    "rgba with float"
+  );
+  assertEquals(
     tinycolor({ r: 255, g: 0, b: 0 }).toHexString(),
     "#ff0000",
     "object input"

--- a/test.js
+++ b/test.js
@@ -330,14 +330,14 @@ Deno.test("RGB Text Parsing", function () {
     "parenthesized spaced input"
   );
   assertEquals(
-    tinycolor("rgba(255, 25.5, 0, 0.5)").toRgb(),
+    tinycolor("rgba(33.3, 66.7, 1, 0.5)").toRgbValues(),
     {
-      r: 255,
-      g: 25.5,
-      b: 0,
+      r: 33.3,
+      g: 66.7,
+      b: 1,
       a: 0.5,
     },
-    "rgba with float"
+    "toRgbValues"
   );
   assertEquals(
     tinycolor({ r: 255, g: 0, b: 0 }).toHexString(),

--- a/tinycolor.js
+++ b/tinycolor.js
@@ -137,6 +137,14 @@
         a: this._a
       };
     },
+    toRgbValues: function toRgbValues() {
+      return {
+        r: this._r,
+        g: this._g,
+        b: this._b,
+        a: this._a
+      };
+    },
     toRgbString: function toRgbString() {
       return this._a == 1 ? "rgb(" + Math.round(this._r) + ", " + Math.round(this._g) + ", " + Math.round(this._b) + ")" : "rgba(" + Math.round(this._r) + ", " + Math.round(this._g) + ", " + Math.round(this._b) + ", " + this._roundA + ")";
     },


### PR DESCRIPTION
Implements `toRgbValues`. See https://github.com/bgrins/TinyColor/issues/278